### PR TITLE
fix: escape quotes in moduleIds to support webpack loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,10 +188,11 @@ var bundleWithWebpack = function(fn, fnModuleId) {
   var modulesString;
 
   if (devMode) {
-    fnModuleId = '"' + fnModuleId + '"';
+    // must escape quotes to support webpack loader options
+    fnModuleId = '"' + fnModuleId.replace(/"/g, '\\\"') + '"';
     // dev mode in webpack4, modules are passed as an object
     var mappedSourceStrings = Object.keys(sourceStrings).map(function(sKey) {
-      return '"' + sKey + '":' + sourceStrings[sKey];
+      return '"' + sKey.replace(/"/g, '\\\"') + '":' + sourceStrings[sKey];
     });
 
     modulesString = '{' + mappedSourceStrings.join(',') + '}';


### PR DESCRIPTION
webpack loaders can be activated with options that may contain quotes `"`
e.g. `import style from 'css-loader?{"key":"value"}!style.css';`

This change makes sure to escape any quotes in module ids so valid javascript is output

Address issue found here https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-373436692